### PR TITLE
Changed createdb to superuser for postgress user

### DIFF
--- a/salt/roots/salt/postgresql/init.sls
+++ b/salt/roots/salt/postgresql/init.sls
@@ -18,7 +18,7 @@ Install PostgreSQL:
 Create PostgreSQL user:
   postgres_user.present:
     - name: {{ pillar['db']['username'] }}
-    - createdb: True
+    - superuser: True
     - password: {{ pillar['db']['password'] }}
     - user: postgres
     - require:


### PR DESCRIPTION
This pullrequest changes the ``createdb`` setting while creating the postgresql user to ``superuser``. This way the user is able to install postgresql extension like ``hstore``.